### PR TITLE
Sort the directory files by name

### DIFF
--- a/packages/codegen/src/create_icon_file.rs
+++ b/packages/codegen/src/create_icon_file.rs
@@ -82,6 +82,7 @@ pub fn create_icon_file(svg_path: &str, output_path: &str, icon_prefix: &str) {
 
 fn collect_svg_files(svg_path: &str, icon_prefix: &str) -> Vec<PathBuf> {
     let dir_entries = WalkDir::new(svg_path)
+        .sort_by_file_name()
         .into_iter()
         .filter_map(|e| e.ok())
         .collect::<Vec<_>>();


### PR DESCRIPTION
Force Walkdir to  sort files by name to ensure a deterministic icons generation.